### PR TITLE
Removes CSS file paths from manifest

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -18,8 +18,7 @@
     {
       "all_frames": false,
       "matches": ["http://*/*", "https://*/*"],
-      "js": ["content.js"],
-      "css": ["assets/css/palette.css"]
+      "js": ["content.js"]
     }
   ],
   "icons": {
@@ -29,5 +28,5 @@
   },
   "permissions": ["storage"],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'; connect-src ws://localhost:*/",
-  "web_accessible_resources": ["assets/img/*", "assets/css/*"]
+  "web_accessible_resources": ["assets/img/*"]
 }


### PR DESCRIPTION
When you build the current project and try to load it in Google Chrome, it shows an error with this message
> "Could not load css 'assets/css/palette.css' for content script.'
> "Could not load manifest."

This is because there is no "css" directory with any CSS files in the build folder. Removing it makes the plugin load and work as expected!